### PR TITLE
修正因为pytz.timezone('Asia/Tokyo')实际对应"LMT","JST","JDT"3个时区，…

### DIFF
--- a/plugin/TenHouPlugin/TenHou.py
+++ b/plugin/TenHouPlugin/TenHou.py
@@ -141,8 +141,8 @@ async def asyautoget_th_match() -> list:
                     # msg = "检测到新的对局信息:\n"
                     msg = ""
                     msg += f"{model}\n"
-                    localtime = datetime.datetime.strptime(f"{usetime['date']} {startTime}", TIME_FORMAT) \
-                        .replace(tzinfo=jptz).astimezone().strftime(TIME_FORMAT)
+                    localtime = jptz.localize(datetime.datetime.strptime(f"{usetime['date']} {startTime}", TIME_FORMAT)) \
+                        .astimezone().strftime(TIME_FORMAT)
                     msg += f"{localtime}，对局时长: {duration}\n"
                     order = get_matchorder(
                         playerlist=plname, playername=p)


### PR DESCRIPTION
…而datetime.replace(tzinfo=tz)会误用LMT时区而产生的错误